### PR TITLE
Resolve directory navigation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Useful Utilities
 A Set of useful tools for Development
 
-#GitHub Organization Sync Utility 
-(/bash-scripts/buildSourceTree.sh)
-This script will build a full Organization Github clone environment. 
-		This was designed for use on a Mac, but Linux with bash should work
-		This will only handle organization with less than 400 Repos (Assuming paging limits on GitHub API)
-    Build to help sync Github to OpenGrok
-    Also useful to keep the complete organization source code pulled and refreshed for development
+## GitHub Organization Sync Utility  
+**Location:** (/bash-scripts/buildSourceTree.sh)  
+- This script will build a full Organization Github clone environment. 
+- This was designed for use on a Mac, but Linux with bash should work
+- This will only handle organizations with less than 400 Repos (Assuming paging limits on GitHub API)
+- Built to help sync Github to OpenGrok
+- Also useful to keep the complete organization source code pulled and refreshed for development
     

--- a/bash-scripts/buildSourceTree.sh
+++ b/bash-scripts/buildSourceTree.sh
@@ -76,9 +76,9 @@ curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/re
 curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=3" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "/usr/bin/git clone ssh://git@github.com/" org "/"  $1 ".git"}' >>  $SubD/cloneRepo.sh
 
 
-curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=1" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "cd ~/" subdir "/" $1 "\n/usr/bin/git pull ssh://git@github.com/" org "/"  $1 ".git\ncd ~"}' >  $SubD/pullRepo.sh
-curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=2" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "cd ~/" subdir "/" $1 "\n/usr/bin/git pull ssh://git@github.com/" org "/"  $1 ".git\ncd ~"}' >>  $SubD/pullRepo.sh
-curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=3" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "cd ~/" subdir "/" $1 "\n/usr/bin/git pull ssh://git@github.com/" org "/"  $1 ".git\ncd ~"}' >>  $SubD/pullRepo.sh
+curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=1" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "cd " $1 "\n/usr/bin/git pull ssh://git@github.com/" org "/"  $1 ".git\ncd .."}' >  $SubD/pullRepo.sh
+curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=2" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "cd " $1 "\n/usr/bin/git pull ssh://git@github.com/" org "/"  $1 ".git\ncd .."}' >>  $SubD/pullRepo.sh
+curl --user "$Username:$Password1" -s "https://api.github.com/orgs/$GitHubOrg/repos?per_page=100&page=3" | grep -e 'git_url*' | cut -d \" -f 4 | cut -d / -f 5 | cut -d . -f 1 | awk -v subdir=$SubD -v org=$GitHubOrg -v user=$Username '{print "cd " $1 "\n/usr/bin/git pull ssh://git@github.com/" org "/"  $1 ".git\ncd .."}' >>  $SubD/pullRepo.sh
 
 chmod 700 $SubD/cloneRepo.sh
 chmod 700 $SubD/pullRepo.sh


### PR DESCRIPTION
the buildSourceTree script creates the $SubD based off of the location of the script. However when it creates the pullRepo script it uses "~" which is the root of the user's folder and not the location of the script. Adjusting to be based on the location of the buildSourceTree script makes this work correctly
